### PR TITLE
Small fix to the login screen to normalize behaviour between switching fragments

### DIFF
--- a/CircuitMessing/app/src/main/java/com/example/circuitmessing/LoginActivity.kt
+++ b/CircuitMessing/app/src/main/java/com/example/circuitmessing/LoginActivity.kt
@@ -47,7 +47,8 @@ class LoginActivity : AppCompatActivity() {
 
         val signUpButton = loginBindingView.signUpButton
         val signInButton = loginBindingView.signInButton
-
+        val toggleGroup = loginBindingView.loginToggleButton
+        toggleGroup.check(signInButton.id)
 
         signUpButton.setOnClickListener(){
             showRegisterFragment()

--- a/CircuitMessing/app/src/main/res/layout/activity_login.xml
+++ b/CircuitMessing/app/src/main/res/layout/activity_login.xml
@@ -40,8 +40,10 @@
         android:layout_width="400dp"
         android:layout_height="75dp"
         android:layout_marginTop="50dp"
-        android:layout_marginBottom="15dp"
-        android:layout_gravity="center">
+        android:layout_marginBottom="25dp"
+        android:layout_gravity="center"
+        app:singleSelection="true"
+        app:selectionRequired="true">
 
         <Button
             android:id="@+id/signInButton"

--- a/CircuitMessing/app/src/main/res/layout/fragment_login_fragment.xml
+++ b/CircuitMessing/app/src/main/res/layout/fragment_login_fragment.xml
@@ -6,7 +6,7 @@
     android:layout_height="match_parent"
     tools:context=".ui.auth.fragment_login">
 
-    <androidx.constraintlayout.widget.ConstraintLayout android:layout_width="match_parent" android:layout_height="300dp">
+    <androidx.constraintlayout.widget.ConstraintLayout android:layout_width="match_parent" android:layout_height="350dp">
 
         <com.google.android.material.textfield.TextInputLayout
             android:id="@+id/username_field"

--- a/CircuitMessing/app/src/main/res/layout/fragment_register_fragment.xml
+++ b/CircuitMessing/app/src/main/res/layout/fragment_register_fragment.xml
@@ -8,7 +8,7 @@
 
     <androidx.constraintlayout.widget.ConstraintLayout
         android:layout_width="match_parent"
-        android:layout_height="357dp">
+        android:layout_height="350dp">
 
         <com.google.android.material.textfield.TextInputLayout
             android:id="@+id/username_field"


### PR DESCRIPTION

[FIX] Set Sign In button to be initially selected, toggle group set to single select and selection required so it behaves as it should now, normalized the height of login and register fragments so input fields dont jump around when switching views